### PR TITLE
Added functionality to handle uncertainty masking in negative years

### DIFF
--- a/lib/edtf/uncertainty.rb
+++ b/lib/edtf/uncertainty.rb
@@ -86,9 +86,15 @@ module EDTF
     end
 
     def mask(values)
-      values.zip(members.take(values.length)).map do |value, mask|
+      if values[0] && values[0][0] == "-"
+        values[0].delete!("-") 
+        negative_year = true
+      end
+      results = values.zip(members.take(values.length)).map do |value, mask|
         value.split(//).zip(send(mask)).map { |v,m| m ? U : v }.join
       end
+      results[0] = "-#{results[0]}" if negative_year
+      results
     end
   end
 

--- a/spec/edtf/uncertainty_spec.rb
+++ b/spec/edtf/uncertainty_spec.rb
@@ -186,6 +186,31 @@ module EDTF
 				
 			end
 			
+      context 'when passed an array with a negative year string' do
+        let(:date) { ['-1994'] }
+          
+        it 'should return the array with the year by default' do
+          expect(u.mask(date)).to eq(['-1994'])
+        end
+
+        context 'when the year is unspecified' do
+          before(:each) { u.year[3] = true }
+          
+          it 'should return the array with the year and the fourth digit masked' do
+            expect(u.mask(date)).to eq(['-199u'])
+          end      
+        end
+
+        context 'when the decade is unspecified' do
+          before(:each) { u.year[2,2] = [true,true] }
+          
+          it 'should return the array with the year and the third and fourth digit masked' do
+            expect(u.mask(date)).to eq(['-19uu'])
+          end
+          
+        end
+      end
+
 			context 'when passed an array with a year-month string' do
 				let(:date) { ['1994', '01'] }
 				


### PR DESCRIPTION
There's possibly a cleaner way to do this, but this makes the problem go away and fixes issue #23.