### PR TITLE
Require active_support before requiring its components

### DIFF
--- a/lib/edtf.rb
+++ b/lib/edtf.rb
@@ -37,6 +37,7 @@ require 'forwardable'
 require 'enumerator'
 require 'set'
 
+require 'active_support'
 require 'active_support/core_ext/date/calculations'
 require 'active_support/core_ext/date_time/calculations'
 require 'active_support/core_ext/time/calculations'


### PR DESCRIPTION
See https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support.

This is only a problem when using this gem outside the context of a Rails application with active_support 7.x.  Older versions recommended doing this in the documentation but didn't break either.