### PR TITLE
Fix Ruby 3 support

### DIFF
--- a/lib/edtf/season.rb
+++ b/lib/edtf/season.rb
@@ -109,7 +109,7 @@ module EDTF
 
     def each
       if block_given?
-        to_range.each(&Proc.new)
+        to_range.each { |r| yield(r) }
         self
       else
         to_enum


### PR DESCRIPTION
Use explicit call to yield instead of implicit block to proc creation

I ran into an error on this line when attempting to upgrade my application to ruby 3.1 and found that this change fixed it.