### PR TITLE
implement include? for open sets (fixes #46)

### DIFF
--- a/lib/edtf/parser.rb
+++ b/lib/edtf/parser.rb
@@ -871,7 +871,7 @@ Racc_token_to_s_table = [
   "d01_30" ]
 Ractor.make_shareable(Racc_token_to_s_table) if defined?(Ractor)
 
-Racc_debug_parser = false
+Racc_debug_parser = true
 
 ##### State transition tables end #####
 

--- a/lib/edtf/set.rb
+++ b/lib/edtf/set.rb
@@ -7,7 +7,6 @@ module EDTF
     include Comparable
 
     def_delegators :@dates, :size, :length, :empty?
-    def_delegators :to_a, :include?
 
     attr_accessor :choice, :later, :earlier
 
@@ -28,6 +27,21 @@ module EDTF
         self
       end
     end
+
+    def include?(v)
+      return false unless v.is_a?(Date)
+      return false if empty?
+
+      dates_array = to_a
+      if earlier?
+        (min = dates_array.first) >= v && min.precision == v.precision
+      elsif later?
+        (max = dates_array.last) <= v && max.precision == v.precision
+      else
+        dates_array.member?(v)
+      end
+    end
+    alias member? include?
 
     def <<(date)
       dates << date

--- a/spec/edtf/set_spec.rb
+++ b/spec/edtf/set_spec.rb
@@ -52,7 +52,7 @@ module EDTF
       end
 
       it 'does not include the date 1671-01-01' do
-        expect(set.include?(Date.new(1671))).to be false
+        expect(set.include?(Date.new(1671).day_precision!)).to be false
       end
 
       it 'does not include the year 1669' do
@@ -101,6 +101,168 @@ module EDTF
       it "maps to the 4 months 1760-12 through 1761-03" do
         expected_months = %w[1760-12 1761-01 1761-02 1761-03].map { |m| Date.edtf(m) }
         expect(set.to_a).to eq(expected_months)
+      end
+    end
+
+    context "open sets" do
+      describe 'the set {..1984}' do
+        let(:set) { Date.edtf('{..1984}') }
+
+        it "is not a choice" do
+          expect(set).not_to be_choice
+        end
+
+        it 'includes the date 1984' do
+          expect(set.include?(Date.new(1984).year_precision!)).to be true
+        end
+
+        it 'includes the date 1984 BCE' do
+          expect(set.include?(Date.new(-1984).year_precision!)).to be true
+        end
+
+        it 'does not include the date 1995' do
+          expect(set.include?(Date.new(1995).year_precision!)).to be false
+        end
+      end
+
+      describe 'the set {..1984-05-11}' do
+        let(:set) { Date.edtf('{..1984-05-11}') }
+
+        it "is not a choice" do
+          expect(set).not_to be_choice
+        end
+
+        it 'includes the date 1984-05-11' do
+          expect(set.include?(Date.new(1984, 5, 11))).to be true
+        end
+
+        it 'includes the date 11 May 1984 BCE' do
+          expect(set.include?(Date.new(-1984, 5, 11))).to be true
+        end
+
+        it 'does not include the date 1995-01-01' do
+          expect(set.include?(Date.new(1995))).to be false
+        end
+      end
+
+      describe 'the set {1984..}' do
+        let(:set) { Date.edtf('{1984..}') }
+
+        it "is not a choice" do
+          expect(set).not_to be_choice
+        end
+
+        it 'includes the date 1984' do
+          expect(set.include?(Date.new(1984).year_precision!)).to be true
+        end
+
+        it 'does not include the date 1984 BCE' do
+          expect(set.include?(Date.new(-1984).year_precision!)).to be false
+        end
+
+        it 'includes the date 1995' do
+          expect(set.include?(Date.new(1995).year_precision!)).to be true
+        end
+      end
+
+      describe 'the set {1984-05-11..}' do
+        let(:set) { Date.edtf('{1984-05-11..}') }
+
+        it "is not a choice" do
+          expect(set).not_to be_choice
+        end
+
+        it 'includes the date 1984-05-11' do
+          expect(set.include?(Date.new(1984, 5, 11))).to be true
+        end
+
+        it 'does not include the date 11 May 1984 BCE' do
+          expect(set.include?(Date.new(-1984, 5, 11))).to be false
+        end
+
+        it 'includes the date 1995-01-01' do
+          expect(set.include?(Date.new(1995))).to be true
+        end
+      end
+
+      describe 'the set [..1984]' do
+        let(:set) { Date.edtf('[..1984]') }
+
+        it "is a choice" do
+          expect(set).to be_choice
+        end
+
+        it 'includes the date 1984' do
+          expect(set.include?(Date.new(1984).year_precision!)).to be true
+        end
+
+        it 'includes the date 1984 BCE' do
+          expect(set.include?(Date.new(-1984).year_precision!)).to be true
+        end
+
+        it 'does not include the date 1995' do
+          expect(set.include?(Date.new(1995).year_precision!)).to be false
+        end
+      end
+
+      describe 'the set [..1984-05-11]' do
+        let(:set) { Date.edtf('[..1984-05-11]') }
+
+        it "is a choice" do
+          expect(set).to be_choice
+        end
+
+        it 'includes the date 1984-05-11' do
+          expect(set.include?(Date.new(1984, 5, 11))).to be true
+        end
+
+        it 'includes the date 11 May 1984 BCE' do
+          expect(set.include?(Date.new(-1984, 5, 11))).to be true
+        end
+
+        it 'does not include the date 1995-01-01' do
+          expect(set.include?(Date.new(1995))).to be false
+        end
+      end
+
+      describe 'the set [1984..]' do
+        let(:set) { Date.edtf('[1984..]') }
+
+        it "is a choice" do
+          expect(set).to be_choice
+        end
+
+        it 'includes the date 1984' do
+          expect(set.include?(Date.new(1984).year_precision!)).to be true
+        end
+
+        it 'does not include the date 1984 BCE' do
+          expect(set.include?(Date.new(-1984).year_precision!)).to be false
+        end
+
+        it 'includes the date 1995' do
+          expect(set.include?(Date.new(1995).year_precision!)).to be true
+        end
+      end
+
+      describe 'the set [1984-05-11..]' do
+        let(:set) { Date.edtf('[1984-05-11..]') }
+
+        it "is a choice" do
+          expect(set).to be_choice
+        end
+
+        it 'includes the date 1984-05-11' do
+          expect(set.include?(Date.new(1984, 5, 11))).to be true
+        end
+
+        it 'does not include the date 11 May 1984 BCE' do
+          expect(set.include?(Date.new(-1984, 5, 11))).to be false
+        end
+
+        it 'includes the date 1995-01-01' do
+          expect(set.include?(Date.new(1995))).to be true
+        end
       end
     end
   end


### PR DESCRIPTION
Adds an explicit implementation of `include?` to `EDTF::Set` that takes into account the `earlier` and `later` flags (fixes #43)
